### PR TITLE
Added support for Safari push notifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ These are all Accessor attributes.
 | `expiration` | "
 | `priority` | "
 | `topic` | "
+| `url_args` | `Array` Values for [Safari push notifications](https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12)
 
 For example:
 
@@ -177,6 +178,17 @@ notification.sound    = "bells.wav"
 notification.priority = 5
 ```
 
+For a [Safari push notification](https://developer.apple.com/notifications/safari-push-notifications/):
+
+```ruby
+notification = Apnotic::Notification.new(token)
+notification.alert = {
+  title: "Flight A998 Now Boarding",
+  body: "Boarding has begun for Flight A998.",
+  action: "View"
+}
+notification.url_args = ["boarding", "A998"]
+```
 
 ### `Apnotic::Response`
 The response to a call to `connection.push`.

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -5,7 +5,7 @@ module Apnotic
 
   class Notification
     attr_reader :token
-    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload
+    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args
     attr_accessor :apns_id, :expiration, :priority, :topic
 
     def initialize(token)
@@ -25,6 +25,7 @@ module Apnotic
       aps.merge!(sound: sound) if sound
       aps.merge!(content_available: content_available) if content_available
       aps.merge!(category: category) if category
+      aps.merge!('url-args' => url_args) if url_args
 
       n = { aps: aps }
       n.merge!(custom_payload) if custom_payload

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -98,5 +98,30 @@ describe Apnotic::Notification do
         }.to_json
       ) }
     end
+
+    context "when sending Safari push notifications" do
+
+      before do
+        notification.alert = {
+          title: "Flight A998 Now Boarding",
+          body: "Boarding has begun for Flight A998.",
+          action: "View"
+        }
+        notification.url_args = [1, 2]
+      end
+
+      it { is_expected.to eq (
+        {
+          aps:   {
+            alert: {
+              title: "Flight A998 Now Boarding",
+              body: "Boarding has begun for Flight A998.",
+              action: "View"
+            },
+            'url-args' => [1, 2]
+          }
+        }.to_json
+      ) }
+    end
   end
 end


### PR DESCRIPTION
[Safari push notifications](https://developer.apple.com/notifications/safari-push-notifications/) use the same interface as device notifications. The only difference is the requirement of a url-args key. This adds support for the key.