### PR TITLE
Added support for mutable-content key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ These are all Accessor attributes.
 | `priority` | "
 | `topic` | "
 | `url_args` | Values for [Safari push notifications](https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12).
+| `mutable_content` | Key for [UNNotificationServiceExtension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension).
 
 For example:
 

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -5,7 +5,7 @@ module Apnotic
 
   class Notification
     attr_reader :token
-    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args
+    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content
     attr_accessor :apns_id, :expiration, :priority, :topic
 
     def initialize(token)
@@ -28,6 +28,7 @@ module Apnotic
       aps.merge!(category: category) if category
       aps.merge!('content-available' => content_available) if content_available
       aps.merge!('url-args' => url_args) if url_args
+      aps.merge!('mutable-content' => mutable_content) if mutable_content
 
       n = { aps: aps }
       n.merge!(custom_payload) if custom_payload

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -91,6 +91,7 @@ describe Apnotic::Notification do
         notification.content_available = 1
         notification.category          = "action_one"
         notification.custom_payload    = { acme1: "bar" }
+        notification.mutable_content   = 1
       end
 
       it { is_expected.to eq (
@@ -100,7 +101,8 @@ describe Apnotic::Notification do
             badge:             22,
             sound:             "sound.wav",
             category:          "action_one",
-            'content-available' => 1
+            'content-available' => 1,
+            'mutable-content'   => 1
           },
           acme1: "bar"
         }.to_json


### PR DESCRIPTION
The mutable-content key was introduced in iOS 10 and allows you to alter a notification in a [UNNotificationServiceExtension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension). This enables things like media attachments:

<img width="383" alt="screen shot 2016-06-17 at 3 43 05 pm" src="https://cloud.githubusercontent.com/assets/133809/16166685/486ebfe8-34a2-11e6-9ae4-f7eba4bf1381.png">


There's more information about this key in the [Advanced Notifications](https://developer.apple.com/videos/play/wwdc2016/708/) session.