### PR TITLE
add support for apns-collapse-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ These are all Accessor attributes.
 | `topic` | "
 | `url_args` | Values for [Safari push notifications](https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12).
 | `mutable_content` | Key for [UNNotificationServiceExtension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension).
+| `apns_collapse_id` | Key for setting the identification of a notification and allowing for the updating of the content of that notification in a subsequent push. More information avaible in [WWDC 2016 - Session 707 Introduction to Notifications](https://developer.apple.com/videos/play/wwdc2016/707/?time=1134). iOS 10+
 
 For example:
 

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -6,7 +6,7 @@ module Apnotic
   class Notification
     attr_reader :token
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content
-    attr_accessor :apns_id, :expiration, :priority, :topic
+    attr_accessor :apns_id, :expiration, :priority, :topic, :apns_collapse_id
 
     def initialize(token)
       @token   = token

--- a/lib/apnotic/request.rb
+++ b/lib/apnotic/request.rb
@@ -17,6 +17,7 @@ module Apnotic
       h.merge!('apns-expiration' => notification.expiration) if notification.expiration
       h.merge!('apns-priority' => notification.priority) if notification.priority
       h.merge!('apns-topic' => notification.topic) if notification.topic
+      h.merge!('apns-collapse-id' => notification.apns_collapse_id) if notification.apns_collapse_id
       h
     end
   end

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -32,16 +32,18 @@ describe Apnotic::Notification do
     describe "request specifics" do
 
       before do
-        notification.apns_id    = "apns-id"
-        notification.expiration = 1461491082
-        notification.priority   = 10
-        notification.topic      = "com.example.myapp"
+        notification.apns_id            = "apns-id"
+        notification.expiration         = 1461491082
+        notification.priority           = 10
+        notification.topic              = "com.example.myapp"
+        notification.apns_collapse_id   = "collpase-id"
       end
 
       it { is_expected.to have_attributes(apns_id: "apns-id") }
       it { is_expected.to have_attributes(expiration: 1461491082) }
       it { is_expected.to have_attributes(priority: 10) }
       it { is_expected.to have_attributes(topic: "com.example.myapp") }
+      it { is_expected.to have_attributes(apns_collapse_id: "collpase-id") }
     end
   end
 

--- a/spec/apnotic/request_spec.rb
+++ b/spec/apnotic/request_spec.rb
@@ -23,11 +23,12 @@ describe Apnotic::Request do
 
   describe "#build_headers_for" do
     let(:notification) do
-      n            = Apnotic::Notification.new("phone-token")
-      n.apns_id    = "apns-id"
-      n.expiration = 1461491082
-      n.priority   = 10
-      n.topic      = "com.example.myapp"
+      n                  = Apnotic::Notification.new("phone-token")
+      n.apns_id          = "apns-id"
+      n.expiration       = 1461491082
+      n.priority         = 10
+      n.topic            = "com.example.myapp"
+      n.apns_collapse_id = "collapse-id"
       n
     end
 
@@ -39,10 +40,11 @@ describe Apnotic::Request do
 
     it { is_expected.to eq (
       {
-        "apns-id"         => "apns-id",
-        "apns-expiration" => 1461491082,
-        "apns-priority"   => 10,
-        "apns-topic"      => "com.example.myapp"
+        "apns-id"          => "apns-id",
+        "apns-expiration"  => 1461491082,
+        "apns-priority"    => 10,
+        "apns-topic"       => "com.example.myapp",
+        "apns-collapse-id" => "collapse-id"
       }
     ) }
   end


### PR DESCRIPTION
I'm working on iOS 10 notifications and needed to support apns-collapse-id in the header values so that the value of an existing push could be updated with another remote notification with the same apns-collapse-id.  Realize I should have created a ticket to discuss first, but anyhow work is done and tests are passing, hopefully acceptable.  Worked perfect for me.  