### PR TITLE
Add token-based authentication.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'net-http2', github: 'feedbin/net-http2', ref: '8be56ce'

--- a/README.md
+++ b/README.md
@@ -92,6 +92,25 @@ connection.join
 connection.close
 ```
 
+#### Token-based authentication
+Token-based authentication is supported. There are several advantages with token-based auth:
+
+- There is no need to renew push certificates annually.
+- A single key can be used for every app in your developer account.
+
+First, you will need a [token signing key](http://help.apple.com/xcode/mac/current/#/dev54d690a66?sub=dev1eb5dfe65) from your Apple developer account.
+
+Then configure your connection for `:token` authentication:
+
+```ruby
+require 'apnotic'
+connection = Apnotic::Connection.new(
+  auth_method: :token,
+  cert_path: "key.p8",
+  key_id: "p8_key_id",
+  team_id: "apple_team_id"
+)
+```
 
 ### With Sidekiq / Rescue / ...
 > In case that errors are encountered, Apnotic will raise the error and repair the underlying connection, but it will not retry the requests that have failed. This is by design,  so that the job manager (Sidekiq, Resque,...) can retry the job that failed. For this reason, it is recommended to use a queue engine that will retry unsuccessful pushes.
@@ -184,7 +203,7 @@ Allows to set a callback for the connection. The only available event is `:error
 connection.on(:error) { |exception| puts "Exception has been raised: #{exception}" }
 ```
 
-> If the `:error` callback is not set, the underlying socket thread may raise an error in the main thread at unexpected execution times. 
+> If the `:error` callback is not set, the underlying socket thread may raise an error in the main thread at unexpected execution times.
 
  * **url** → **`URL`**
 
@@ -291,11 +310,11 @@ The response to a call to `connection.push`.
  * **body** → **`hash` or `string`**
 
  Returns the body of the response in Hash format if a valid JSON was returned, otherwise just the RAW body.
- 
+
   * **headers** → **`hash`**
 
  Returns a Hash containing the Headers of the response.
- 
+
  * **ok?** → **`boolean`**
 
  Returns if the push was successful.
@@ -311,9 +330,9 @@ The push object to be sent in an async call.
 #### Methods
 
  * **http2_request**  → **`NetHttp2::Request`**
- 
+
  Returns the HTTP/2 request of the push.
- 
+
  * **on(event, &block)**
 
  Allows to set a callback for the request. Available events are:

--- a/lib/apnotic.rb
+++ b/lib/apnotic.rb
@@ -1,3 +1,5 @@
+require 'apnotic/instance_cache'
+require 'apnotic/provider_token'
 require 'apnotic/connection'
 require 'apnotic/connection_pool'
 require 'apnotic/notification'

--- a/lib/apnotic/connection.rb
+++ b/lib/apnotic/connection.rb
@@ -21,6 +21,10 @@ module Apnotic
       @cert_path       = options[:cert_path]
       @cert_pass       = options[:cert_pass]
       @connect_timeout = options[:connect_timeout] || 30
+      @auth_method     = options[:auth_method] || :cert
+      @team_id         = options[:team_id]
+      @key_id          = options[:key_id]
+      @first_push      = true
 
       raise "Cert file not found: #{@cert_path}" unless @cert_path && (@cert_path.respond_to?(:read) || File.exist?(@cert_path))
 
@@ -28,7 +32,7 @@ module Apnotic
     end
 
     def push(notification, options={})
-      request  = Apnotic::Request.new(notification)
+      request  = prepare_request(notification)
       response = @client.call(:post, request.path,
         body:    request.body,
         headers: request.headers,
@@ -38,11 +42,16 @@ module Apnotic
     end
 
     def push_async(push)
-      @client.call_async(push.http2_request)
+      if @first_push
+        @first_push = false
+        @client.call_async(push.http2_request)
+      else
+        delayed_push_async(push)
+      end
     end
 
     def prepare_push(notification)
-      request       = Apnotic::Request.new(notification)
+      request       = prepare_request(notification)
       http2_request = @client.prepare_request(:post, request.path,
         body:    request.body,
         headers: request.headers
@@ -64,8 +73,39 @@ module Apnotic
 
     private
 
+    def prepare_request(notification)
+      notification.authorization = provider_token if @auth_method == :token
+      Apnotic::Request.new(notification)
+    end
+
+    def delayed_push_async(push)
+      if streams_available?
+        @client.call_async(push.http2_request)
+      else
+        sleep 0.001
+        delayed_push_async(push)
+      end
+    end
+
+    def streams_available?
+      remote_max_concurrent_streams - @client.stream_count > 0
+    end
+
+    def remote_max_concurrent_streams
+      # 0x7fffffff is the default value from http-2 gem (2^31)
+      if @client.remote_settings[:settings_max_concurrent_streams] == 0x7fffffff
+        0
+      else
+        @client.remote_settings[:settings_max_concurrent_streams]
+      end
+    end
+
     def ssl_context
-      @ssl_context ||= begin
+      @auth_method == :cert ? build_ssl_context : nil
+    end
+
+    def build_ssl_context
+      @build_ssl_context ||= begin
         ctx = OpenSSL::SSL::SSLContext.new
         begin
           p12      = OpenSSL::PKCS12.new(certificate, @cert_pass)
@@ -90,5 +130,14 @@ module Apnotic
         cert
       end
     end
+
+    def provider_token
+      @provider_token_cache ||= begin
+        instance = ProviderToken.new(certificate, @team_id, @key_id)
+        InstanceCache.new(instance, :token, 30 * 60)
+      end
+      @provider_token_cache.call
+    end
+
   end
 end

--- a/lib/apnotic/instance_cache.rb
+++ b/lib/apnotic/instance_cache.rb
@@ -1,0 +1,28 @@
+module Apnotic
+  class InstanceCache
+    def initialize(instance, method, ttl)
+      @instance = instance
+      @method   = method
+      @ttl      = ttl
+    end
+
+    def call
+      if @cached_value && !expired?
+        @cached_value
+      else
+        new_value
+      end
+    end
+
+    private
+
+    def expired?
+      Time.now - @cached_at >= @ttl
+    end
+
+    def new_value
+      @cached_at = Time.now
+      @cached_value = @instance.send(@method)
+    end
+  end
+end

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -6,7 +6,7 @@ module Apnotic
   class Notification
     attr_reader :token
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content
-    attr_accessor :apns_id, :expiration, :priority, :topic, :apns_collapse_id
+    attr_accessor :apns_id, :expiration, :priority, :topic, :apns_collapse_id, :authorization
 
     def initialize(token)
       @token   = token
@@ -15,6 +15,10 @@ module Apnotic
 
     def body
       JSON.dump(to_hash).force_encoding(Encoding::BINARY)
+    end
+
+    def authorization_header
+      authorization ? "bearer #{authorization}" : nil
     end
 
     private

--- a/lib/apnotic/provider_token.rb
+++ b/lib/apnotic/provider_token.rb
@@ -1,0 +1,43 @@
+require 'base64'
+require 'openssl'
+require 'json'
+
+module Apnotic
+  class ProviderToken
+    def initialize(key, team_id, key_id)
+      @key     = OpenSSL::PKey::EC.new(key)
+      @team_id = team_id
+      @key_id  = key_id
+    end
+
+    def token
+      [encode(header), encode(payload), encode(signature)].join(".")
+    end
+
+    private
+
+    def header
+      JSON.generate({
+        alg: "ES256",
+        kid: @key_id
+      })
+    end
+
+    def payload
+      JSON.generate({
+        iss: @team_id,
+        iat: Time.now.to_i
+      })
+    end
+
+    def signature
+      data = [encode(header), encode(payload)].join(".")
+      digest = OpenSSL::Digest::SHA256.new().digest(data)
+      @key.dsa_sign_asn1(digest)
+    end
+
+    def encode(data)
+      Base64.encode64(data).tr('+/', '-_').gsub(/[\n=]/, '')
+    end
+  end
+end

--- a/lib/apnotic/request.rb
+++ b/lib/apnotic/request.rb
@@ -18,6 +18,7 @@ module Apnotic
       h.merge!('apns-priority' => notification.priority) if notification.priority
       h.merge!('apns-topic' => notification.topic) if notification.topic
       h.merge!('apns-collapse-id' => notification.apns_collapse_id) if notification.apns_collapse_id
+      h.merge!('authorization' => notification.authorization_header) if notification.authorization_header
       h
     end
   end

--- a/spec/apnotic/instance_cache_spec.rb
+++ b/spec/apnotic/instance_cache_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Apnotic::InstanceCache do
+  let(:seconds) { 60 }
+  let(:instance_cache) do
+    Apnotic::InstanceCache.new(Time, :now, seconds)
+  end
+
+  describe "instance cache" do
+    subject { instance_cache }
+
+    it "has the same token in the same period" do
+      original = subject.call
+      valid_time = Time.now + seconds - 1
+      allow(Time).to receive(:now).and_return(valid_time)
+      expect(original).to eq subject.call
+    end
+
+    it "should change after ttl expires" do
+      original = subject.call
+      expired_time = Time.now + seconds
+      allow(Time).to receive(:now).and_return(expired_time)
+      expect(original).not_to eq subject.call
+    end
+  end
+end

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -37,13 +37,15 @@ describe Apnotic::Notification do
         notification.priority           = 10
         notification.topic              = "com.example.myapp"
         notification.apns_collapse_id   = "collpase-id"
+        notification.authorization      = "token"
       end
 
       it { is_expected.to have_attributes(apns_id: "apns-id") }
       it { is_expected.to have_attributes(expiration: 1461491082) }
       it { is_expected.to have_attributes(priority: 10) }
       it { is_expected.to have_attributes(topic: "com.example.myapp") }
-      it { is_expected.to have_attributes(apns_collapse_id: "collpase-id") }
+      it { is_expected.to have_attributes(authorization: "token") }
+      it { is_expected.to have_attributes(authorization_header: "bearer token") }
     end
   end
 

--- a/spec/apnotic/provider_token_spec.rb
+++ b/spec/apnotic/provider_token_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Apnotic::ProviderToken do
+  def decode(data)
+    data += '=' * (4 - data.length.modulo(4))
+    Base64.decode64(data.tr('-_', '+/'))
+  end
+
+  let(:team_id) { "team_id" }
+  let(:key_id) { "key_id" }
+  let(:private_key) do
+    OpenSSL::PKey::EC.new('prime256v1').tap do |key|
+      key.generate_key
+    end
+  end
+  let(:public_key) do
+    OpenSSL::PKey::EC.new(private_key).tap do |key|
+      key.private_key = nil
+    end
+  end
+  let(:provider_token) do
+    Apnotic::ProviderToken.new(private_key, team_id, key_id)
+  end
+
+  describe "token" do
+    subject { provider_token.token }
+    describe "should build token" do
+      it "generates a json web token" do
+        expect(subject).to be_truthy
+      end
+    end
+  end
+
+  describe "header" do
+    subject do
+      header, _, _ = provider_token.token.split(".")
+      JSON.parse(decode(header))
+    end
+    it { is_expected.to eq({"alg"=>"ES256", "kid"=>key_id}) }
+  end
+
+  describe "payload" do
+    subject do
+      _, payload, _ = provider_token.token.split(".")
+      JSON.parse(decode(payload))
+    end
+    let(:time_now) { Time.now }
+    it do
+      allow(Time).to receive(:now).and_return(time_now)
+      is_expected.to eq({"iss"=>team_id, "iat"=>time_now.to_i})
+    end
+  end
+
+  describe "signature" do
+    it "has a valid signature" do
+      data = provider_token.token
+      header, payload, signature = data.split(".")
+      signature = decode(signature)
+      digest = OpenSSL::Digest::SHA256.new().digest("#{header}.#{payload}")
+      result = public_key.dsa_verify_asn1(digest, signature)
+      expect(result).to eq true
+    end
+
+  end
+
+end

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -56,7 +56,7 @@ module Apnotic
       private
 
       def handle(socket)
-        conn = HTTP2::Server.new
+        conn = HTTP2::Server.new(settings_max_concurrent_streams: 1)
 
         conn.on(:frame) { |bytes| socket.write(bytes) }
 


### PR DESCRIPTION
Hello,

Apple recently added support for authenticating via JSON Web Token instead of and SSL certificate. The key advantages are that the key never expires and can be used for multiple apps.
- [Provider Authentication Tokens docs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html#//apple_ref/doc/uid/TP40008194-CH101-SW21)
- Provision [Apple Push Notification Authentication Key](https://developer.apple.com/account/ios/certificate/create)

I've made the updates to support JWTs, minus some tests.

However I was wondering if this is something you would be interested in having in Apnotic and if so could get some help before continuing?

When I run this with jwt it looks like the connection is closed immediately and no notifications are sent:

``` ruby
APNOTIC_POOL = Apnotic::ConnectionPool.new(
  {
    auth_method: :token,
    cert_path: ENV['APPLE_KEY'],
    team_id:   ENV['APPLE_TEAM_ID'],
    key_id:    ENV['APPLE_KEY_ID'],
  },
  size: 5
)
APNOTIC_POOL.with do |connection|
  notifications.each do |_, notification|
    push = connection.prepare_push(notification)
    push.on(:response) do |response|
      if response.status == '410' || (response.status == '400' && response.body['reason'] == 'BadDeviceToken')
        # handle failure
      end
    end
    connection.push_async(push)
  end
  connection.join
end
EOFError: end of file reached
    from /Users/ben/.rbenv/versions/2.3.1/lib/ruby/2.3.0/openssl/buffering.rb:178:in `sysread_nonblock'
    from /Users/ben/.rbenv/versions/2.3.1/lib/ruby/2.3.0/openssl/buffering.rb:178:in `read_nonblock'
    from /Users/ben/Sites/feedbin/vendor/bundle/gems/net-http2-0.13.3/lib/net-http2/client.rb:111:in `block in socket_loop'
    from /Users/ben/Sites/feedbin/vendor/bundle/gems/net-http2-0.13.3/lib/net-http2/client.rb:108:in `loop'
    from /Users/ben/Sites/feedbin/vendor/bundle/gems/net-http2-0.13.3/lib/net-http2/client.rb:108:in `socket_loop'
    from /Users/ben/Sites/feedbin/vendor/bundle/gems/net-http2-0.13.3/lib/net-http2/client.rb:93:in `block (2 levels) in ensure_open'
```

It could just be that the JWT part is not what Apple is expecting, but I'm able to sign and decode the JWT in the `spec/apnotic/provider_token_spec.rb`.

Any thoughts about what might be going wrong would be great.

Thanks!
