### PR TITLE
allow a cert to be passed in as a pem string and not a file

### DIFF
--- a/lib/apnotic/connection.rb
+++ b/lib/apnotic/connection.rb
@@ -19,10 +19,13 @@ module Apnotic
     def initialize(options={})
       @url             = options[:url] || APPLE_PRODUCTION_SERVER_URL
       @cert_path       = options[:cert_path]
+      @certificate     = options[:certificate]
       @cert_pass       = options[:cert_pass]
       @connect_timeout = options[:connect_timeout] || 30
 
-      raise "Cert file not found: #{@cert_path}" unless @cert_path && (@cert_path.respond_to?(:read) || File.exist?(@cert_path))
+      if options[:certificate].nil?
+        raise "Cert file not found: #{@cert_path}" unless @cert_path && (@cert_path.respond_to?(:read) || File.exist?(@cert_path))
+      end
 
       @client = NetHttp2::Client.new(@url, ssl_context: ssl_context, connect_timeout: @connect_timeout)
     end
@@ -58,6 +61,18 @@ module Apnotic
       @client.join
     end
 
+    def certificate
+      @certificate ||= begin
+        if @cert_path.respond_to?(:read)
+          cert = @cert_path.read
+          @cert_path.rewind if @cert_path.respond_to?(:rewind)
+        else
+          cert = File.read(@cert_path)
+        end
+        cert
+      end
+    end
+
     private
 
     def ssl_context
@@ -72,18 +87,6 @@ module Apnotic
           ctx.cert = OpenSSL::X509::Certificate.new(certificate)
         end
         ctx
-      end
-    end
-
-    def certificate
-      @certificate ||= begin
-        if @cert_path.respond_to?(:read)
-          cert = @cert_path.read
-          @cert_path.rewind if @cert_path.respond_to?(:rewind)
-        else
-          cert = File.read(@cert_path)
-        end
-        cert
       end
     end
   end

--- a/spec/apnotic/connection_spec.rb
+++ b/spec/apnotic/connection_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Apnotic::Connection do
   let(:url) { "https://localhost" }
   let(:cert_path) { apn_file_path }
+  let(:cert) { File.read apn_file_path }
   let(:connection) do
     Apnotic::Connection.new({
       url:       url,
@@ -29,6 +30,31 @@ describe Apnotic::Connection do
         let(:url) { "https://localhost:4343" }
 
         it { is_expected.to eq "https://localhost:4343" }
+      end
+    end
+
+
+    describe "option: certificate" do
+      let(:connection) do
+        Apnotic::Connection.new({
+          url:          url,
+          certificate:  cert,
+          cert_pass:    ""
+        })
+      end
+
+      subject { connection.certificate }
+
+      context "when it is a PEM string" do
+        it { is_expected.to eq File.read cert_path }
+      end
+
+      context "when it is a PEM string" do
+        it "is equivalent to loading in the certificate from a path" do
+          p12_connection = Apnotic::Connection.new(url: url, cert_path: apn_p12_file_path)
+          expect(connection.send(:ssl_context).key.to_pem).to eq p12_connection.send(:ssl_context).key.to_pem
+          expect(connection.send(:ssl_context).cert.to_pem).to eq p12_connection.send(:ssl_context).cert.to_pem
+        end
       end
     end
 


### PR DESCRIPTION
This change allows an optional PEM encoded string to replace the file read in from disk.

This change is important if you need to use multiple certificates in the same app.
