### PR TITLE
support generic notifications with the goal of supporting mdm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ These are all Accessor attributes.
 
 | Method | Documentation
 |-----|-----
+| `payload` | Replaces ALL subsiquent values with the payload specified. This is useful if you wish to send an MDM payload.
 | `alert` | Refer to the official Apple documentation of [The Notification Payload](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html) for details.
 | `badge` | "
 | `sound` | "
@@ -257,6 +258,13 @@ notification.alert    = {
   action: "View"
 }
 notification.url_args = ["boarding", "A998"]
+```
+
+For an MDM push notification.
+
+```ruby
+notification            = Apnotic::Notification.new(token)
+notification.payload    = {mdm: "YOUR-MDM-PUSH-MAGIC-TOKEN"}
 ```
 
 ### `Apnotic::Response`

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -6,7 +6,7 @@ module Apnotic
   class Notification
     attr_reader :token
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content
-    attr_accessor :apns_id, :expiration, :priority, :topic, :apns_collapse_id
+    attr_accessor :apns_id, :expiration, :priority, :topic, :apns_collapse_id, :payload
 
     def initialize(token)
       @token   = token
@@ -20,6 +20,7 @@ module Apnotic
     private
 
     def to_hash
+      return payload if payload
       aps = {}
 
       aps.merge!(alert: alert) if alert

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -136,4 +136,31 @@ describe Apnotic::Notification do
       ) }
     end
   end
+
+  describe "arbitray payload" do
+
+    subject { notification }
+    let(:mdm_payload) { { mdm: "A47EA72E-0A82-4B05-8ADE-5EEB3F103EB1" } }
+
+    describe "mdm payload" do
+
+      before do
+        notification.payload = mdm_payload
+      end
+
+
+      it { is_expected.to have_attributes(payload: mdm_payload) }
+    end
+
+    describe "mdm payload body" do
+
+      subject { notification.body }
+
+      before do
+        notification.payload = mdm_payload
+      end
+
+      it { is_expected.to eq (mdm_payload.to_json) }
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses #32.

Unfortunately the Apple documentation for this is private.
I have tried to make this generic to support arbitrary payloads as I think there are some other types.
