### PR TITLE
Fix Apple documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,13 @@ These are all Accessor attributes.
 
 | Method | Documentation
 |-----|-----
-| `alert` | Refer to the official Apple documentation of [The Notification Payload](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html) for details.
+| `alert` | Refer to the official Apple documentation of [The Notification Payload](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html) for details.
 | `badge` | "
 | `sound` | "
 | `content_available` | "
 | `category` | "
 | `custom_payload` | "
-| `apns_id` | Refer to the [APNs Provider API](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html) for details.
+| `apns_id` | Refer to the [APNs Provider API](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for details.
 | `expiration` | "
 | `priority` | "
 | `topic` | "


### PR DESCRIPTION
I noticed a couple links in the readme are broken. I'm not very familiar with APNs, so these may not be the correct links, but at least it starts the conversation :)

Thanks for the useful library!