### PR TITLE
Add thread-id to Apnotic::Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ These are all Accessor attributes.
 | `content_available` | "
 | `category` | "
 | `custom_payload` | "
+| `thread_id` | "
 | `apns_id` | Refer to [Communicating with APNs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for details.
 | `expiration` | "
 | `priority` | "

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -3,7 +3,7 @@ require 'apnotic/abstract_notification'
 module Apnotic
 
   class Notification < AbstractNotification
-    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content
+    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
 
     private
 
@@ -16,6 +16,7 @@ module Apnotic
         result.merge!('content-available' => content_available) if content_available
         result.merge!('url-args' => url_args) if url_args
         result.merge!('mutable-content' => mutable_content) if mutable_content
+        result.merge!('thread-id' => thread_id) if thread_id
       end
     end
 

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -16,6 +16,7 @@ describe Apnotic::Notification do
         notification.sound             = "sound.wav"
         notification.content_available = false
         notification.category          = "action_one"
+        notification.thread_id         = 'action_id'
         notification.custom_payload    = { acme1: "bar" }
       end
 
@@ -25,6 +26,7 @@ describe Apnotic::Notification do
       it { is_expected.to have_attributes(sound: "sound.wav") }
       it { is_expected.to have_attributes(content_available: false) }
       it { is_expected.to have_attributes(category: "action_one") }
+      it { is_expected.to have_attributes(thread_id: "action_id") }
       it { is_expected.to have_attributes(custom_payload: { acme1: "bar" }) }
     end
 
@@ -94,6 +96,7 @@ describe Apnotic::Notification do
         notification.sound             = "sound.wav"
         notification.content_available = 1
         notification.category          = "action_one"
+        notification.thread_id         = 'action_id'
         notification.custom_payload    = { acme1: "bar" }
         notification.mutable_content   = 1
       end
@@ -106,7 +109,8 @@ describe Apnotic::Notification do
             sound:             "sound.wav",
             category:          "action_one",
             'content-available' => 1,
-            'mutable-content'   => 1
+            'mutable-content'   => 1,
+            'thread-id'         => 'action_id'
           },
           acme1: "bar"
         }.to_json


### PR DESCRIPTION
According to [Apple's official documentation], you could pass in the `thread-id` key to APNs as an identifier for grouping notifications, but I noticed the `Apnotic::Notification` class doesn't allow for assigning it.

This PR adds the ability to set a value to the `thread-id` key so all the APS dictionary keys in their offitial doc will be covered and sent over to APNs.

[Apple's official documentation]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html\#//apple_ref/doc/uid/TP40008194-CH17-SW3