### PR TITLE
no not include 'aps' hash when there's only a custom_payload specified

### DIFF
--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -30,7 +30,8 @@ module Apnotic
       aps.merge!('url-args' => url_args) if url_args
       aps.merge!('mutable-content' => mutable_content) if mutable_content
 
-      n = { aps: aps }
+      n = { }
+      n.merge!(aps: aps) if aps.size > 0 || custom_payload.nil?
       n.merge!(custom_payload) if custom_payload
       n
     end

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -69,6 +69,18 @@ describe Apnotic::Notification do
       ) }
     end
 
+    context "when only a custom payload is specified do not add an empty aps" do
+      before do
+        notification.custom_payload = { mdm: "my-push-magic" }
+      end
+
+      it { is_expected.to eq (
+        {
+          mdm: "my-push-magic"
+        }.to_json
+      ) }
+    end
+
     context "when only alert is specified" do
 
       before do


### PR DESCRIPTION
Hey there,

we're working on a MDM (mobile device management) solution for iOS devices and `apnotic` seems like the best gem for sending push notifications over http2 right now.

There was a small issue, though - MDM push notifications are of a special kind; Apple explicitly states that there shouldn't be a `aps` key within the push notification body (https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/3-MDM_Protocol/MDM_Protocol.html#//apple_ref/doc/uid/TP40017387-CH3-SW3).

As luck would have it, it was easy enough to patch the library so that it doesn't send the `aps` key if it's empty. I'm not entirely familiar with regular push notifications - I was hoping this change doesn't break any existing behavior (in other words: are push notifications with an empty `aps` even valid?).

Anyways. Please let me know what you think.

Best!
Bruno



