### PR TITLE
Support Proxy setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ Apnotic::Connection.new(options)
 | :cert_pass | Optional. The certificate's password.
 | :url | Optional. Defaults to https://api.push.apple.com:443.
 | :connect_timeout | Optional. Expressed in seconds, defaults to 30.
+| :proxy_addr | Optional.  Proxy server. e.g. http://proxy.example.com
+| :proxy_port | Optional.  Proxy port. e.g. 8080
+| :proxy_user | Optional.  User name for proxy authentication. e.g. user_name
+| :proxy_pass | Optional.  Password for proxy authentication. e.g. pass_word
 
 Note that since `:cert_path` can be any object that responds to `:read`, it is possible to pass in a certificate string directly by wrapping it up in a `StringIO` object:
 

--- a/lib/apnotic/connection.rb
+++ b/lib/apnotic/connection.rb
@@ -5,6 +5,7 @@ module Apnotic
 
   APPLE_DEVELOPMENT_SERVER_URL = "https://api.sandbox.push.apple.com:443"
   APPLE_PRODUCTION_SERVER_URL  = "https://api.push.apple.com:443"
+  PROXY_SETTINGS_KEYS = [:proxy_addr, :proxy_port, :proxy_user, :proxy_pass]
 
   class Connection
     attr_reader :url, :cert_path
@@ -28,7 +29,15 @@ module Apnotic
 
       raise "Cert file not found: #{@cert_path}" unless @cert_path && (@cert_path.respond_to?(:read) || File.exist?(@cert_path))
 
-      @client = NetHttp2::Client.new(@url, ssl_context: ssl_context, connect_timeout: @connect_timeout)
+      http2_options = {
+        ssl_context: ssl_context,
+        connect_timeout: @connect_timeout
+      }
+      PROXY_SETTINGS_KEYS.each do |key|
+        http2_options[key] = options[key] if options[key]
+      end
+
+      @client = NetHttp2::Client.new(@url, http2_options)
     end
 
     def push(notification, options={})

--- a/spec/apnotic/connection_spec.rb
+++ b/spec/apnotic/connection_spec.rb
@@ -3,11 +3,25 @@ require 'spec_helper'
 describe Apnotic::Connection do
   let(:url) { "https://localhost" }
   let(:cert_path) { apn_file_path }
+  let(:proxy_settings) {
+    {
+      proxy_addr: "http://proxy",
+      proxy_port: "8080",
+      proxy_user: "proxy-user",
+      proxy_pass: "proxy-pass"
+    }
+  }
   let(:connection) do
     Apnotic::Connection.new({
       url:       url,
       cert_path: cert_path
     })
+  end
+  let(:connection_proxy) do
+    Apnotic::Connection.new({
+      url:       url,
+      cert_path: cert_path
+    }.merge(proxy_settings))
   end
 
   describe ".new" do
@@ -61,6 +75,17 @@ describe Apnotic::Connection do
           io_connection = Apnotic::Connection.new(url: url, cert_path: StringIO.new(File.read(apn_file_path)))
           expect(connection.send(:ssl_context).key.to_pem).to eq io_connection.send(:ssl_context).key.to_pem
           expect(connection.send(:ssl_context).cert.to_pem).to eq io_connection.send(:ssl_context).cert.to_pem
+        end
+      end
+    end
+
+    describe "option: proxy family" do
+      context "when proxy is set" do
+        it "has proxy-assigned NetHttp2 instance" do
+          client = connection_proxy.instance_variable_get(:@client)
+          proxy_settings.each do |k, v|
+            expect(client.instance_variable_get("@#{k}")).to eq v
+          end
         end
       end
     end


### PR DESCRIPTION
This PR is for supporting HTTP proxy, for Issue #76.
Just passing HTTP proxy settings to `NetHttp2::Client` instance.

Could you review this PR, please? Thank you!
