### PR TITLE
Relax connection pool dependency

### DIFF
--- a/apnotic.gemspec
+++ b/apnotic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-http2", ">= 0.18", "< 2"
-  spec.add_dependency "connection_pool", "~> 2.0"
+  spec.add_dependency "connection_pool", ">= 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I tried to use Apnotic with the latest Sidkiq release and hit a dependency snag with connection_pool.