### PR TITLE
Hint at using RAILS_MAX_THREADS as ConnectionPool size

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ class MyWorker
   APNOTIC_POOL = Apnotic::ConnectionPool.new({
     cert_path: Rails.root.join("config", "certs", "apns_certificate.pem"),
     cert_pass: "mypass"
-  }, size: 5) do |connection|
+  }, size: ENV.fetch("RAILS_MAX_THREADS") { 5 }) do |connection|
     connection.on(:error) { |exception| puts "Exception has been raised: #{exception}" }
   end
 


### PR DESCRIPTION
Similar to how Rails configures the [ActiveRecord pool](https://github.com/rails/rails/blob/0223665c971b98fe0ac82b78b485ee1330d4c1e3/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt#L22) and the [Puma thread count](https://github.com/rails/rails/blob/0223665c971b98fe0ac82b78b485ee1330d4c1e3/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt#L7) by default. Also how Sidekiq configures its [concurrency](https://github.com/mperham/sidekiq/blob/a281aa44a63ea17e0b14f955ffd7d2c9ac147ef5/lib/sidekiq/cli.rb#L260) and [Redis pool](https://github.com/mperham/sidekiq/blob/ea30e975ba0b80dc1f41eb09470bbdf27f5abb96/lib/sidekiq/redis_connection.rb#L18-L23).

I believe this is how most apps should configure Apnotic. Any reason for setting a pool size that’s different from your thread count?