### PR TITLE
Fix to ensure one stream is always available.

### DIFF
--- a/lib/apnotic/connection.rb
+++ b/lib/apnotic/connection.rb
@@ -101,7 +101,7 @@ module Apnotic
     def remote_max_concurrent_streams
       # 0x7fffffff is the default value from http-2 gem (2^31)
       if @client.remote_settings[:settings_max_concurrent_streams] == 0x7fffffff
-        0
+        1
       else
         @client.remote_settings[:settings_max_concurrent_streams]
       end


### PR DESCRIPTION
As discussed in #75, apnotic can block forever if the underlying connection fails. This was introduced in my [addition of token-based authentication](https://github.com/ostinelli/apnotic/pull/28) and this pull request will fix the issue.

When using token-based auth, there is always at least [one connection open](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns):

> APNs allows only one stream until you post a request with a valid authentication token. 

By leaving this connection available, apnotic has the opportunity to repair the connection, and resume sending notifications.