### PR TITLE
Add apns-push-type header

### DIFF
--- a/lib/apnotic/abstract_notification.rb
+++ b/lib/apnotic/abstract_notification.rb
@@ -26,6 +26,10 @@ module Apnotic
       authorization ? "bearer #{authorization}" : nil
     end
 
+    def background_notification?
+      false
+    end
+
     private
 
     def to_hash

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -5,6 +5,10 @@ module Apnotic
   class Notification < AbstractNotification
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
 
+    def background_notification?
+      aps.count == 1 && aps.key?('content-available')
+    end
+
     private
 
     def aps

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -6,7 +6,7 @@ module Apnotic
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
 
     def background_notification?
-      aps.count == 1 && aps.key?('content-available')
+      aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1
     end
 
     private

--- a/lib/apnotic/request.rb
+++ b/lib/apnotic/request.rb
@@ -16,6 +16,7 @@ module Apnotic
       h.merge!('apns-id' => notification.apns_id) if notification.apns_id
       h.merge!('apns-expiration' => notification.expiration) if notification.expiration
       h.merge!('apns-priority' => notification.priority) if notification.priority
+      h.merge!('apns-push-type' => notification.background_notification? ? 'background' : 'alert' )
       h.merge!('apns-topic' => notification.topic) if notification.topic
       h.merge!('apns-collapse-id' => notification.apns_collapse_id) if notification.apns_collapse_id
       h.merge!('authorization' => notification.authorization_header) if notification.authorization_header

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -142,4 +142,33 @@ describe Apnotic::Notification do
       ) }
     end
   end
+
+  describe "#background_notification?" do
+    subject { notification.background_notification? }
+
+    context "when content-available is not set" do
+      before do
+        notification.alert = "An alert"
+      end
+
+      it { expect(subject).to eq false }
+    end
+
+    context "when only content-available is set to 1" do
+      before do
+        notification.content_available = 1
+      end
+
+      it { expect(subject).to eq true }
+    end
+
+    context "when content-available is set to 1 with others attributes" do
+      before do
+        notification.alert = "An alert"
+        notification.content_available = 1
+      end
+
+      it { expect(subject).to eq false }
+    end
+  end
 end

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -162,6 +162,14 @@ describe Apnotic::Notification do
       it { expect(subject).to eq true }
     end
 
+    context "when only content-available is set to 0" do
+      before do
+        notification.content_available = 0
+      end
+
+      it { expect(subject).to eq false }
+    end
+
     context "when content-available is set to 1 with others attributes" do
       before do
         notification.alert = "An alert"

--- a/spec/apnotic/request_spec.rb
+++ b/spec/apnotic/request_spec.rb
@@ -38,14 +38,34 @@ describe Apnotic::Request do
 
     subject { build_headers }
 
-    it { is_expected.to eq (
-      {
-        "apns-id"          => "apns-id",
-        "apns-expiration"  => "1461491082",
-        "apns-priority"    => "10",
-        "apns-topic"       => "com.example.myapp",
-        "apns-collapse-id" => "collapse-id"
-      }
-    ) }
+    context "when it's an alert notification" do
+      it { is_expected.to eq (
+        {
+          "apns-id"          => "apns-id",
+          "apns-expiration"  => "1461491082",
+          "apns-priority"    => "10",
+          "apns-push-type"   => "alert",
+          "apns-topic"       => "com.example.myapp",
+          "apns-collapse-id" => "collapse-id"
+        }
+      ) }
+    end
+
+    context "when it's a background notification" do
+      before do
+        notification.content_available = 1
+      end
+
+      it { is_expected.to eq (
+        {
+          "apns-id"          => "apns-id",
+          "apns-expiration"  => "1461491082",
+          "apns-priority"    => "10",
+          "apns-push-type"   => "background",
+          "apns-topic"       => "com.example.myapp",
+          "apns-collapse-id" => "collapse-id"
+        }
+      ) }
+    end
   end
 end


### PR DESCRIPTION
Hello!

With iOS 13 we should send a `apns-push-type` header which is set to `background` if it's a silent/background push notification or `alert` if it's display something.

I made this pull request to set the `apns-push-type` header if the aps payload contains only the `content-available` and is equal to 1 (as described in source [2]).

Sources:
[1] https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947610
[2] https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app
