### PR TITLE
Remove aps size check Notification#background_notification?

### DIFF
--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -6,7 +6,7 @@ module Apnotic
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
 
     def background_notification?
-      aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1
+      aps.key?('content-available') && aps['content-available'] == 1
     end
 
     private

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -172,11 +172,11 @@ describe Apnotic::Notification do
 
     context "when content-available is set to 1 with others attributes" do
       before do
-        notification.alert = "An alert"
+        notification.custom_payload = { acme1: "bar" }
         notification.content_available = 1
       end
 
-      it { expect(subject).to eq false }
+      it { expect(subject).to eq true }
     end
   end
 end


### PR DESCRIPTION
Notifications intended to be background were not getting set as expected due to other attributes (for example, custom_payload).

I explained this a bit more in: #90.

We're testing this now on real-world code. I don't see any "gotchas" yet, but our use cases are fairly limited. 