### PR TITLE
Pushkit (VoIP) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,38 @@ response.body     # => ""
 connection.close
 ```
 
+#### Voice Over IP (voip) notifications
+
+If you are building an iOS VoIP App, you can deliver Pushkit voip notifications by overriding `custom_headers` attribute for `apns-push-type`
+
+```ruby
+require 'apnotic'
+
+# create a persistent connection
+connection = Apnotic::Connection.new(cert_path: 'apns_certificate.pem',
+                                     cert_pass: 'pass')
+
+# create a notification for a specific device token
+token = '6c267f26b173cd9595ae2f6702b1ab560371a60e7c8a9e27419bd0fa4a42e58f'
+
+notification       = Apnotic::Notification.new(token)
+notification.custom_headers = {
+  'apns-push-type' => 'voip'
+}
+
+# send (this is a blocking call)
+response = connection.push(notification)
+
+# read the response
+response.ok?      # => true
+response.status   # => '200'
+response.headers  # => {":status"=>"200", "apns-id"=>"6f2cd350-bfad-4af0-a8bc-0d501e9e1799"}
+response.body     # => ""
+
+# close the connection
+connection.close
+```
+
 #### Token-based authentication
 Token-based authentication is supported. There are several advantages with token-based auth:
 

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -3,7 +3,9 @@ require 'apnotic/abstract_notification'
 module Apnotic
 
   class Notification < AbstractNotification
-    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
+    attr_accessor :alert, :badge, :sound, :content_available, :category,
+                  :custom_payload, :url_args, :mutable_content, :thread_id,
+                  :custom_headers
 
     def background_notification?
       aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1

--- a/lib/apnotic/request.rb
+++ b/lib/apnotic/request.rb
@@ -20,6 +20,7 @@ module Apnotic
       h.merge!('apns-topic' => notification.topic) if notification.topic
       h.merge!('apns-collapse-id' => notification.apns_collapse_id) if notification.apns_collapse_id
       h.merge!('authorization' => notification.authorization_header) if notification.authorization_header
+      h.merge! notification.custom_headers if notification.custom_headers
       h
     end
   end

--- a/spec/apnotic/request_spec.rb
+++ b/spec/apnotic/request_spec.rb
@@ -67,5 +67,24 @@ describe Apnotic::Request do
         }
       ) }
     end
+
+    context 'when it''s a voip notification' do
+      before do
+        notification.custom_headers = {
+          'apns-push-type' => 'voip'
+        }
+      end
+
+      it do
+        is_expected.to eq(
+          'apns-id' => 'apns-id',
+          'apns-expiration' => '1461491082',
+          'apns-priority' => '10',
+          'apns-push-type' => 'voip',
+          'apns-topic' => 'com.example.myapp',
+          'apns-collapse-id' => 'collapse-id'
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
- In order to send pushkit notifications, `apns-push-type` must be sent as `voip`
- Since this value is determined based on `content_available` for bg of alert values, the cleanest solution would be to allow overriding the request headers. This solution would also support: `complication` and `fileprovider` notifications.

### Usage:

```ruby
notification = Apnotic::Notification.new(push_token)
notification.custom_headers = {
  'apns-push-type' => 'voip',
  'apns-expiration' => 0
}
...
```

Sources:
- https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/
- https://developer.apple.com/documentation/pushkit/responding_to_voip_notifications_from_pushkit
