### PR TITLE
Add target-content-id & interruption-level & relevance-score to payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ These are all Accessor attributes.
 | `category` | "
 | `custom_payload` | "
 | `thread_id` | "
+| `target_content_id` | "
+| `interruption_level` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 15+
+| `relevance_score` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 15+
 | `apns_id` | Refer to [Communicating with APNs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for details.
 | `expiration` | "
 | `priority` | "

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -4,7 +4,8 @@ module Apnotic
 
   class Notification < AbstractNotification
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
-
+    attr_accessor :target_content_id, :interruption_level, :relevance_score
+    
     def background_notification?
       aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1
     end
@@ -21,6 +22,9 @@ module Apnotic
         result.merge!('url-args' => url_args) if url_args
         result.merge!('mutable-content' => mutable_content) if mutable_content
         result.merge!('thread-id' => thread_id) if thread_id
+        result.merge!('target-content-id' => target_content_id) if target_content_id
+        result.merge!('interruption-level' => interruption_level) if interruption_level
+        result.merge!('relevance-score' => relevance_score) if relevance_score
       end
     end
 

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -7,17 +7,20 @@ describe Apnotic::Notification do
 
     subject { notification }
 
-    # <https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html>
+    # <https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363>
     describe "remote notification payload" do
 
       before do
-        notification.alert             = "Something for you!"
-        notification.badge             = 22
-        notification.sound             = "sound.wav"
-        notification.content_available = false
-        notification.category          = "action_one"
-        notification.thread_id         = 'action_id'
-        notification.custom_payload    = { acme1: "bar" }
+        notification.alert              = "Something for you!"
+        notification.badge              = 22
+        notification.sound              = "sound.wav"
+        notification.content_available  = false
+        notification.category           = "action_one"
+        notification.thread_id          = "action_id"
+        notification.target_content_id  = "target_content_id"
+        notification.interruption_level = "passive"
+        notification.relevance_score    = 0.8
+        notification.custom_payload     = { acme1: "bar" }
       end
 
       it { is_expected.to have_attributes(token: "token") }
@@ -27,6 +30,9 @@ describe Apnotic::Notification do
       it { is_expected.to have_attributes(content_available: false) }
       it { is_expected.to have_attributes(category: "action_one") }
       it { is_expected.to have_attributes(thread_id: "action_id") }
+      it { is_expected.to have_attributes(target_content_id: "target_content_id") }
+      it { is_expected.to have_attributes(interruption_level: "passive") }
+      it { is_expected.to have_attributes(relevance_score: 0.8) }
       it { is_expected.to have_attributes(custom_payload: { acme1: "bar" }) }
     end
 
@@ -91,14 +97,17 @@ describe Apnotic::Notification do
     context "when everything is specified" do
 
       before do
-        notification.alert             = "Something for you!"
-        notification.badge             = 22
-        notification.sound             = "sound.wav"
-        notification.content_available = 1
-        notification.category          = "action_one"
-        notification.thread_id         = 'action_id'
-        notification.custom_payload    = { acme1: "bar" }
-        notification.mutable_content   = 1
+        notification.alert              = "Something for you!"
+        notification.badge              = 22
+        notification.sound              = "sound.wav"
+        notification.content_available  = 1
+        notification.category           = "action_one"
+        notification.thread_id          = 'action_id'
+        notification.target_content_id  = "target_content_id"
+        notification.interruption_level = "passive"
+        notification.relevance_score    = 0.8
+        notification.custom_payload     = { acme1: "bar" }
+        notification.mutable_content    = 1
       end
 
       it { is_expected.to eq (
@@ -108,9 +117,12 @@ describe Apnotic::Notification do
             badge:             22,
             sound:             "sound.wav",
             category:          "action_one",
-            'content-available' => 1,
-            'mutable-content'   => 1,
-            'thread-id'         => 'action_id'
+            'content-available'  => 1,
+            'mutable-content'    => 1,
+            'thread-id'          => 'action_id',
+            'target-content-id'  => 'target_content_id',
+            'interruption-level' => 'passive',
+            'relevance-score'    => 0.8
           },
           acme1: "bar"
         }.to_json


### PR DESCRIPTION
This PR adds 3 payload keys to the `Apnotic::Notification` class:

- `target-content-id` The identifier of the window brought forward since iOS 13.
- `interruption-level` Indicates the importance and delivery timing of a notification for iOS 15.
- `relevance-score` Number to specify the sort of the notifications for iOS 15.

Ref:
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363
https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel
https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore
https://github.com/ostinelli/apnotic/issues/105