### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ It is also possible to create a connection that points to the Apple Development 
 Apnotic::Connection.development(options)
 ```
 
-> The concepts of PRODUCTION and DEVELOPMENT are different from what they used to be in previous specifications. Anything built directly from XCode and loaded on your phone will have the app generate DEVELOPMENT tokens, while everything else (TestFlight, Apple Store, HockeyApp, ...) will be considered as PRODUCTION environment.
+> The concepts of PRODUCTION and DEVELOPMENT are different from what they used to be in previous specifications. Anything built directly from Xcode and loaded on your phone will have the app generate DEVELOPMENT tokens, while everything else (TestFlight, Apple Store, HockeyApp, ...) will be considered as PRODUCTION environment.
 
 #### Methods
 


### PR DESCRIPTION
[According to Apple](https://developer.apple.com/xcode/), it should be spelled "Xcode".