### PR TITLE
Pin OpenSSL security_level to 1 in development.

### DIFF
--- a/lib/apnotic/connection.rb
+++ b/lib/apnotic/connection.rb
@@ -114,6 +114,7 @@ module Apnotic
     def build_ssl_context
       @build_ssl_context ||= begin
         ctx = OpenSSL::SSL::SSLContext.new
+        ctx.security_level = 1 if development? && ctx.respond_to?(:security_level)
         begin
           p12      = OpenSSL::PKCS12.new(certificate, @cert_pass)
           ctx.key  = p12.key
@@ -146,5 +147,8 @@ module Apnotic
       @provider_token_cache.call
     end
 
+    def development?
+      url == APPLE_DEVELOPMENT_SERVER_URL
+    end
   end
 end

--- a/spec/apnotic/connection_spec.rb
+++ b/spec/apnotic/connection_spec.rb
@@ -94,12 +94,18 @@ describe Apnotic::Connection do
   describe ".development" do
     let(:options) { { url: "will-be-overwritten", other: "options" } }
 
+    subject { Apnotic::Connection.development(cert_path: cert_path) }
+
     it "initializes a connection object with url set to APPLE DEVELOPMENT" do
       expect(Apnotic::Connection).to receive(:new).with(options.merge({
         url: "https://api.sandbox.push.apple.com:443"
       }))
 
       Apnotic::Connection.development(options)
+    end
+
+    it "responds to development?" do
+      expect(subject.send(:development?)).to eq true
     end
   end
 


### PR DESCRIPTION
Apple generates development/sandbox SHA-1 signed certificates.

If OpenSSL is configured with a SECLEVEL of 2 or above, an `OpenSSL::SSL::SSLError: SSL_CTX_use_certificate` exception is raised.

This will fix #92.