### PR TITLE
Support payload/request keys for iOS 16 live activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,15 @@ These are all Accessor attributes.
 | `target_content_id` | "
 | `interruption_level` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 15+
 | `relevance_score` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 15+
+| `stale_date` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
+| `content_state` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
+| `timestamp` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
+| `event` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
 | `apns_id` | Refer to [Communicating with APNs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for details.
 | `expiration` | "
 | `priority` | "
 | `topic` | "
+| `push_type` | Refer to [Sending Notification Requests to APNs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns) for details, defaults to alert or background (when content-availabe key is set to 1)
 | `url_args` | Values for [Safari push notifications](https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12).
 | `mutable_content` | Key for [UNNotificationServiceExtension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension).
 | `apns_collapse_id` | Key for setting the identification of a notification and allowing for the updating of the content of that notification in a subsequent push. More information avaible in [WWDC 2016 - Session 707 Introduction to Notifications](https://developer.apple.com/videos/play/wwdc2016/707/?time=1134). iOS 10+

--- a/lib/apnotic/abstract_notification.rb
+++ b/lib/apnotic/abstract_notification.rb
@@ -11,7 +11,8 @@ module Apnotic
                   :priority,
                   :topic,
                   :apns_collapse_id,
-                  :authorization
+                  :authorization,
+                  :push_type
 
     def initialize(token)
       @token   = token

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -5,7 +5,8 @@ module Apnotic
   class Notification < AbstractNotification
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
     attr_accessor :target_content_id, :interruption_level, :relevance_score
-    
+    attr_accessor :stale_date, :content_state, :timestamp, :event
+
     def background_notification?
       aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1
     end
@@ -25,6 +26,10 @@ module Apnotic
         result.merge!('target-content-id' => target_content_id) if target_content_id
         result.merge!('interruption-level' => interruption_level) if interruption_level
         result.merge!('relevance-score' => relevance_score) if relevance_score
+        result.merge!('stale-date' => stale_date) if stale_date
+        result.merge!('content-state' => content_state) if content_state
+        result.merge!('timestamp' => timestamp) if timestamp
+        result.merge!('event' => event) if event
       end
     end
 

--- a/lib/apnotic/request.rb
+++ b/lib/apnotic/request.rb
@@ -16,7 +16,7 @@ module Apnotic
       h.merge!('apns-id' => notification.apns_id) if notification.apns_id
       h.merge!('apns-expiration' => notification.expiration) if notification.expiration
       h.merge!('apns-priority' => notification.priority) if notification.priority
-      h.merge!('apns-push-type' => notification.background_notification? ? 'background' : 'alert' )
+      h.merge!('apns-push-type' => notification.push_type || (notification.background_notification? ? 'background' : 'alert'))
       h.merge!('apns-topic' => notification.topic) if notification.topic
       h.merge!('apns-collapse-id' => notification.apns_collapse_id) if notification.apns_collapse_id
       h.merge!('authorization' => notification.authorization_header) if notification.authorization_header

--- a/spec/apnotic/abstract_notification_spec.rb
+++ b/spec/apnotic/abstract_notification_spec.rb
@@ -18,6 +18,7 @@ describe Apnotic::AbstractNotification do
         notification.topic              = "com.example.myapp"
         notification.apns_collapse_id   = "collpase-id"
         notification.authorization      = "token"
+        notification.push_type          = "liveactivity"
       end
 
       it { is_expected.to have_attributes(apns_id: "apns-id") }
@@ -26,6 +27,7 @@ describe Apnotic::AbstractNotification do
       it { is_expected.to have_attributes(topic: "com.example.myapp") }
       it { is_expected.to have_attributes(authorization: "token") }
       it { is_expected.to have_attributes(authorization_header: "bearer token") }
+      it { is_expected.to have_attributes(push_type: "liveactivity") }
     end
   end
 

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -21,6 +21,10 @@ describe Apnotic::Notification do
         notification.interruption_level = "passive"
         notification.relevance_score    = 0.8
         notification.custom_payload     = { acme1: "bar" }
+        notification.stale_date         = 1650998941
+        notification.content_state      = { content: "content" }
+        notification.timestamp          = 1168364460
+        notification.event              = "update"
       end
 
       it { is_expected.to have_attributes(token: "token") }
@@ -34,6 +38,10 @@ describe Apnotic::Notification do
       it { is_expected.to have_attributes(interruption_level: "passive") }
       it { is_expected.to have_attributes(relevance_score: 0.8) }
       it { is_expected.to have_attributes(custom_payload: { acme1: "bar" }) }
+      it { is_expected.to have_attributes(stale_date: 1650998941) }
+      it { is_expected.to have_attributes(content_state: { content: "content" }) }
+      it { is_expected.to have_attributes(timestamp: 1168364460) }
+      it { is_expected.to have_attributes(event: "update") }
     end
 
     # <https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html>
@@ -46,6 +54,7 @@ describe Apnotic::Notification do
         notification.topic              = "com.example.myapp"
         notification.apns_collapse_id   = "collpase-id"
         notification.authorization      = "token"
+        notification.push_type          = "liveactivity"
       end
 
       it { is_expected.to have_attributes(apns_id: "apns-id") }
@@ -54,6 +63,7 @@ describe Apnotic::Notification do
       it { is_expected.to have_attributes(topic: "com.example.myapp") }
       it { is_expected.to have_attributes(authorization: "token") }
       it { is_expected.to have_attributes(authorization_header: "bearer token") }
+      it { is_expected.to have_attributes(push_type: "liveactivity") }
     end
   end
 
@@ -108,6 +118,10 @@ describe Apnotic::Notification do
         notification.relevance_score    = 0.8
         notification.custom_payload     = { acme1: "bar" }
         notification.mutable_content    = 1
+        notification.stale_date         = 1650998941
+        notification.content_state      = { content: "content" }
+        notification.timestamp          = 1168364460
+        notification.event              = "update"
       end
 
       it { is_expected.to eq (
@@ -122,7 +136,11 @@ describe Apnotic::Notification do
             'thread-id'          => 'action_id',
             'target-content-id'  => 'target_content_id',
             'interruption-level' => 'passive',
-            'relevance-score'    => 0.8
+            'relevance-score'    => 0.8,
+            'stale-date'         => 1650998941,
+            'content-state'      => { content: "content" },
+            'timestamp'          => 1168364460,
+            'event'              => 'update',
           },
           acme1: "bar"
         }.to_json

--- a/spec/apnotic/request_spec.rb
+++ b/spec/apnotic/request_spec.rb
@@ -67,5 +67,22 @@ describe Apnotic::Request do
         }
       ) }
     end
+
+    context "when it's a live activity notification" do
+      before do
+        notification.push_type = 'liveactivity'
+      end
+
+      it { is_expected.to eq (
+        {
+          "apns-id"          => "apns-id",
+          "apns-expiration"  => "1461491082",
+          "apns-priority"    => "10",
+          "apns-push-type"   => "liveactivity",
+          "apns-topic"       => "com.example.myapp",
+          "apns-collapse-id" => "collapse-id"
+        }
+      ) }
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for push payload and request keys used when sending an update to an iOS 16 live activity, as per:

https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications

ie:

* event
* timestamp
* content-state
* stale-date

and additionally a wrapper `push_type` for setting the `apns-push-type` request header with fallback to the existing `background_notification?`  method when unset.

Updates to the README where required.

Confirmed working using my local project.

Thanks for your consideration - any changes or feedback require please let me know 🙏 