### PR TITLE
Live activity `dismissal_date` key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ These are all Accessor attributes.
 | `content_state` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
 | `timestamp` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
 | `event` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
+| `dismissal_date` | Refer to [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363) for details. iOS 16+
 | `apns_id` | Refer to [Communicating with APNs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for details.
 | `expiration` | "
 | `priority` | "

--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -5,7 +5,7 @@ module Apnotic
   class Notification < AbstractNotification
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
     attr_accessor :target_content_id, :interruption_level, :relevance_score
-    attr_accessor :stale_date, :content_state, :timestamp, :event
+    attr_accessor :stale_date, :content_state, :timestamp, :event, :dismissal_date
 
     def background_notification?
       aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1
@@ -30,6 +30,7 @@ module Apnotic
         result.merge!('content-state' => content_state) if content_state
         result.merge!('timestamp' => timestamp) if timestamp
         result.merge!('event' => event) if event
+        result.merge!('dismissal-date' => dismissal_date) if dismissal_date
       end
     end
 

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -122,6 +122,7 @@ describe Apnotic::Notification do
         notification.content_state      = { content: "content" }
         notification.timestamp          = 1168364460
         notification.event              = "update"
+        notification.dismissal_date     = 1168364461
       end
 
       it { is_expected.to eq (
@@ -141,6 +142,7 @@ describe Apnotic::Notification do
             'content-state'      => { content: "content" },
             'timestamp'          => 1168364460,
             'event'              => 'update',
+            'dismissal-date'     => 1168364461,
           },
           acme1: "bar"
         }.to_json


### PR DESCRIPTION
This PR adds support for the `dismissal_date` key that allows one to specify a time when a live activity should be removed from the dynamic island and/or lock screen as per Apple's [docs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363).

Updated specs to validate and README to document.