### PR TITLE
Use memoization for the aps method

### DIFF
--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -14,7 +14,7 @@ module Apnotic
     private
 
     def aps
-      {}.tap do |result|
+      @aps ||= {}.tap do |result|
         result.merge!(alert: alert) if alert
         result.merge!(badge: badge) if badge
         result.merge!(sound: sound) if sound


### PR DESCRIPTION
Hi!

  In `background_notification?`, the `aps` method is called three times and builds a new hash on each call. It would be nice to use memoization. Thank you!