### PR TITLE
Add support for APS attributes and attributes-type keys

### DIFF
--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -6,6 +6,7 @@ module Apnotic
     attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :thread_id
     attr_accessor :target_content_id, :interruption_level, :relevance_score
     attr_accessor :stale_date, :content_state, :timestamp, :event, :dismissal_date
+    attr_accessor :attributes, :attributes_type
 
     def background_notification?
       aps.count == 1 && aps.key?('content-available') && aps['content-available'] == 1
@@ -31,6 +32,8 @@ module Apnotic
         result.merge!('timestamp' => timestamp) if timestamp
         result.merge!('event' => event) if event
         result.merge!('dismissal-date' => dismissal_date) if dismissal_date
+        result.merge!('attributes' => attributes) if attributes
+        result.merge!('attributes-type' => attributes_type) if attributes_type
       end
     end
 

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -25,6 +25,8 @@ describe Apnotic::Notification do
         notification.content_state      = { content: "content" }
         notification.timestamp          = 1168364460
         notification.event              = "update"
+        notification.attributes         = { content: "content" }
+        notification.attributes_type    = 'attributes_type'
       end
 
       it { is_expected.to have_attributes(token: "token") }
@@ -42,6 +44,8 @@ describe Apnotic::Notification do
       it { is_expected.to have_attributes(content_state: { content: "content" }) }
       it { is_expected.to have_attributes(timestamp: 1168364460) }
       it { is_expected.to have_attributes(event: "update") }
+      it { is_expected.to have_attributes(attributes: { content: "content" }) }
+      it { is_expected.to have_attributes(attributes_type: 'attributes_type') }
     end
 
     # <https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html>
@@ -123,6 +127,8 @@ describe Apnotic::Notification do
         notification.timestamp          = 1168364460
         notification.event              = "update"
         notification.dismissal_date     = 1168364461
+        notification.attributes         = { content: "content" }
+        notification.attributes_type    = 'attributes_type'
       end
 
       it { is_expected.to eq (
@@ -143,6 +149,8 @@ describe Apnotic::Notification do
             'timestamp'          => 1168364460,
             'event'              => 'update',
             'dismissal-date'     => 1168364461,
+            'attributes'         => { content: "content" },
+            'attributes-type'    => 'attributes_type'
           },
           acme1: "bar"
         }.to_json


### PR DESCRIPTION
Adds support for the following ["aps" keys](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#2943363):

"attributes": The dictionary that contains data you pass to a Live Activity that you start with a remote push notification. For more information, see Updating and ending your Live Activity with ActivityKit push notifications.

"attributes-type": A string you use when you start a Live Activity with a remote push notification. It must match the name of the structure that describes the dynamic data that appears in a Live Activity. For more information, see Updating and ending your Live Activity with ActivityKit push notifications.

According to the [documentation for Live Activities](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications), these keys should be placed inside "aps".